### PR TITLE
Add ability to install inset lights in top-aligned catwalks

### DIFF
--- a/src/main/java/wile/engineersdecor/ModContent.java
+++ b/src/main/java/wile/engineersdecor/ModContent.java
@@ -382,12 +382,16 @@ public class ModContent
     Registries.addBlock("iron_inset_light", ()->new StandardBlocks.DirectedWaterLoggable(
       StandardBlocks.CFG_CUTOUT|StandardBlocks.CFG_FACING_PLACEMENT|StandardBlocks.CFG_OPPOSITE_PLACEMENT|StandardBlocks.CFG_AI_PASSABLE,
       BlockBehaviour.Properties.of(Material.METAL, MaterialColor.METAL).strength(0.5f, 8f).sound(SoundType.METAL).lightLevel((state)->15).noOcclusion(),
-      Auxiliaries.getPixeledAABB(5.2,5.2,0, 10.8,10.8,0.3)
+      new AABB[] {
+        Auxiliaries.getPixeledAABB( 5,7,0, 11, 9,0.375),
+        Auxiliaries.getPixeledAABB( 6,6,0, 10,10,0.375),
+        Auxiliaries.getPixeledAABB( 7,5,0,  9,11,0.375)
+      }
     ));
     Registries.addBlock("iron_floor_edge_light", ()->new StandardBlocks.DirectedWaterLoggable(
       StandardBlocks.CFG_CUTOUT|StandardBlocks.CFG_LOOK_PLACEMENT|StandardBlocks.CFG_HORIZIONTAL|StandardBlocks.CFG_AI_PASSABLE,
       BlockBehaviour.Properties.of(Material.METAL, MaterialColor.METAL).strength(0.5f, 8f).sound(SoundType.METAL).lightLevel((state)->15).noOcclusion(),
-      Auxiliaries.getPixeledAABB(5,0,0, 11,2,0.5)
+      Auxiliaries.getPixeledAABB(5,0,0, 11,1.8125,0.375)
     ));
     Registries.addBlock("iron_ceiling_edge_light", ()->new StandardBlocks.DirectedWaterLoggable(
       StandardBlocks.CFG_CUTOUT|StandardBlocks.CFG_LOOK_PLACEMENT|StandardBlocks.CFG_HORIZIONTAL|StandardBlocks.CFG_AI_PASSABLE,
@@ -532,8 +536,12 @@ public class ModContent
           Auxiliaries.getPixeledAABB(15, 0, 0, 16, 16, 1),
           Auxiliaries.getPixeledAABB(15, 0,15, 16, 16,16),
           Auxiliaries.getPixeledAABB( 0, 0,15,  1, 16,16)
+        ),
+        Auxiliaries.getUnionShape( // base with inset light
+          Auxiliaries.getPixeledAABB( 0,14,0, 16,16,16)
         )
-      }
+      },
+      Registries.getBlock("iron_inset_light")
     ));
     Registries.addBlock("steel_catwalk_stairs", ()->new EdCatwalkStairsBlock(
       StandardBlocks.CFG_CUTOUT,

--- a/src/main/java/wile/engineersdecor/blocks/EdCatwalkBlock.java
+++ b/src/main/java/wile/engineersdecor/blocks/EdCatwalkBlock.java
@@ -62,7 +62,7 @@ public class EdCatwalkBlock extends StandardBlocks.HorizontalFourWayWaterLoggabl
 
   public static boolean place_consume(BlockState state, Level world, BlockPos pos, Player player, InteractionHand hand, int shrink)
   {
-    if(!world.setBlock(pos, state, 1|2)) return false;
+    if(!world.setBlock(pos, state, Block.UPDATE_ALL)) return false;
     world.playSound(player, pos, SoundEvents.METAL_PLACE, SoundSource.BLOCKS, 1f, 1f);
     if((!player.isCreative()) && (!world.isClientSide())) {
       ItemStack stack = player.getItemInHand(hand);
@@ -94,7 +94,7 @@ public class EdCatwalkBlock extends StandardBlocks.HorizontalFourWayWaterLoggabl
         place_state = place_state.setValue(WATERLOGGED,adjacent_state.getFluidState().getType()==Fluids.WATER);
         place_consume(place_state, world, adjacent_pos, player, hand, 1);
       }
-      return world.isClientSide() ? InteractionResult.SUCCESS : InteractionResult.CONSUME;
+      return InteractionResult.sidedSuccess(world.isClientSide());
     }
     if(block == railing_block) {
       Direction face = hit.getDirection();
@@ -108,14 +108,14 @@ public class EdCatwalkBlock extends StandardBlocks.HorizontalFourWayWaterLoggabl
       } else {
         // far automatic placement
         face = Direction.getNearest(player.getLookAngle().x, 0, player.getLookAngle().z);
-        List<Direction> free_sides = Arrays.stream(Direction.values()).filter(d->d.getAxis().isHorizontal() && (world.getBlockState(pos.relative(d)).getBlock()!=this)).collect(Collectors.toList());
-        if(free_sides.isEmpty()) return world.isClientSide() ? InteractionResult.SUCCESS : InteractionResult.CONSUME;
+        List<Direction> free_sides = Arrays.stream(Direction.values()).filter(d -> d.getAxis().isHorizontal() && (world.getBlockState(pos.relative(d)).getBlock() != this)).toList();
+        if(free_sides.isEmpty()) return InteractionResult.sidedSuccess(world.isClientSide());
         if(!free_sides.contains(face)) face = free_sides.get(0);
       }
       BooleanProperty railing = getDirectionProperty(face);
       boolean add = (!state.getValue(railing));
       place_consume(state.setValue(railing, add), world, pos, player, hand, add ? 1 : -1);
-      return world.isClientSide() ? InteractionResult.SUCCESS : InteractionResult.CONSUME;
+      return InteractionResult.sidedSuccess(world.isClientSide());
     }
     return InteractionResult.PASS;
   }
@@ -131,7 +131,7 @@ public class EdCatwalkBlock extends StandardBlocks.HorizontalFourWayWaterLoggabl
     List<ItemStack> drops = new ArrayList<>();
     drops.add(new ItemStack(state.getBlock().asItem()));
     int n = (state.getValue(NORTH)?1:0)+(state.getValue(EAST)?1:0)+(state.getValue(SOUTH)?1:0)+(state.getValue(WEST)?1:0);
-    if(n > 0) drops.add(new ItemStack(ModContent.getBlock("steel_railing"), n));
+    if(n > 0) drops.add(new ItemStack(railing_block, n));
     return drops;
   }
 

--- a/src/main/java/wile/engineersdecor/blocks/EdCatwalkTopAlignedBlock.java
+++ b/src/main/java/wile/engineersdecor/blocks/EdCatwalkTopAlignedBlock.java
@@ -120,7 +120,7 @@ public class EdCatwalkTopAlignedBlock extends StandardBlocks.WaterLoggable
   private BlockState adapted_state(BlockState state, LevelAccessor world, BlockPos pos)
   {
     BlockState below = world.getBlockState(pos.below());
-    if (state.getValue(VARIANT) == 4) return state;
+    if (state == null || state.getValue(VARIANT) == 4) return state;
     if((below.getBlock() == ModContent.getBlock("thick_steel_pole")) || (below.getBlock() == ModContent.getBlock("thick_steel_pole_head"))) return state.setValue(VARIANT, 1);
     if((below.getBlock() == ModContent.getBlock("thin_steel_pole")) || (below.getBlock() == ModContent.getBlock("thin_steel_pole_head"))) return state.setValue(VARIANT, 2);
     return state;

--- a/src/main/java/wile/engineersdecor/blocks/EdCatwalkTopAlignedBlock.java
+++ b/src/main/java/wile/engineersdecor/blocks/EdCatwalkTopAlignedBlock.java
@@ -46,7 +46,7 @@ public class EdCatwalkTopAlignedBlock extends StandardBlocks.WaterLoggable
 {
   public static final IntegerProperty VARIANT = IntegerProperty.create("variant", 0, 4);
   protected final List<VoxelShape> variant_shapes;
-  final Block inset_light_block;
+  protected final Block inset_light_block;
 
   public EdCatwalkTopAlignedBlock(long config, BlockBehaviour.Properties properties, final VoxelShape[] variant_shapes, final Block inset_light_block)
   {

--- a/src/main/java/wile/engineersdecor/blocks/EdCatwalkTopAlignedBlock.java
+++ b/src/main/java/wile/engineersdecor/blocks/EdCatwalkTopAlignedBlock.java
@@ -13,13 +13,16 @@ import net.minecraft.core.Direction;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.item.context.DirectionalPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
@@ -33,20 +36,24 @@ import wile.engineersdecor.ModContent;
 import wile.engineersdecor.libmc.blocks.StandardBlocks;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
 
 public class EdCatwalkTopAlignedBlock extends StandardBlocks.WaterLoggable
 {
-  public static final IntegerProperty VARIANT = IntegerProperty.create("variant", 0, 3);
+  public static final IntegerProperty VARIANT = IntegerProperty.create("variant", 0, 4);
   protected final List<VoxelShape> variant_shapes;
+  final Block inset_light_block;
 
-  public EdCatwalkTopAlignedBlock(long config, BlockBehaviour.Properties properties, final VoxelShape[] variant_shapes)
+  public EdCatwalkTopAlignedBlock(long config, BlockBehaviour.Properties properties, final VoxelShape[] variant_shapes, final Block inset_light_block)
   {
     super(config, properties, variant_shapes[0]);
     registerDefaultState(super.defaultBlockState().setValue(VARIANT, 0));
     this.variant_shapes = VARIANT.getPossibleValues().stream().map(i->(i<variant_shapes.length) ? (variant_shapes[i]) : (Shapes.block())).collect(Collectors.toList());
+    this.inset_light_block = inset_light_block;
   }
 
   @Override
@@ -81,16 +88,27 @@ public class EdCatwalkTopAlignedBlock extends StandardBlocks.WaterLoggable
   public InteractionResult use(BlockState state, Level world, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hit)
   {
     final Item item = player.getItemInHand(hand).getItem();
-    if(item != this.asItem()) return InteractionResult.PASS;
-    if(hit.getDirection().getAxis().isHorizontal()) return InteractionResult.PASS;
-    BlockPos adjacent_pos = pos.relative(player.getDirection());
-    BlockState adjacent_state = world.getBlockState(adjacent_pos);
-    if(adjacent_state.canBeReplaced(new DirectionalPlaceContext(world, adjacent_pos, hit.getDirection().getOpposite(), player.getItemInHand(hand), hit.getDirection()))) {
-      BlockState place_state = defaultBlockState();
-      place_state = place_state.setValue(WATERLOGGED,adjacent_state.getFluidState().getType()==Fluids.WATER);
-      EdCatwalkBlock.place_consume(adapted_state(place_state, world, adjacent_pos), world, adjacent_pos, player, hand, 1);
+    if((!(item instanceof BlockItem))) return InteractionResult.PASS;
+    final Block block = ((BlockItem)item).getBlock();
+    if(block == this) {
+      if (hit.getDirection().getAxis().isHorizontal()) return InteractionResult.PASS;
+      BlockPos adjacent_pos = pos.relative(player.getDirection());
+      BlockState adjacent_state = world.getBlockState(adjacent_pos);
+      if (adjacent_state.canBeReplaced(new DirectionalPlaceContext(world, adjacent_pos, hit.getDirection().getOpposite(), player.getItemInHand(hand), hit.getDirection()))) {
+        BlockState place_state = defaultBlockState();
+        place_state = place_state.setValue(WATERLOGGED, adjacent_state.getFluidState().getType() == Fluids.WATER);
+        EdCatwalkBlock.place_consume(adapted_state(place_state, world, adjacent_pos), world, adjacent_pos, player, hand, 1);
+      }
+      return InteractionResult.sidedSuccess(world.isClientSide());
     }
-    return world.isClientSide() ? InteractionResult.SUCCESS : InteractionResult.CONSUME;
+    if(block == inset_light_block && hit.getDirection() == Direction.DOWN) {
+      int currentVariant = state.getValue(VARIANT);
+      if (!(currentVariant == 0 || currentVariant == 4)) return InteractionResult.PASS;
+      boolean add = currentVariant == 0;
+      EdCatwalkBlock.place_consume(adapted_state(state.setValue(VARIANT, add ? 4 : 0), world, pos), world, pos, player, hand, add ? 1 : -1);
+      return InteractionResult.sidedSuccess(world.isClientSide());
+    }
+    return InteractionResult.PASS;
   }
 
   @Override
@@ -102,10 +120,31 @@ public class EdCatwalkTopAlignedBlock extends StandardBlocks.WaterLoggable
   private BlockState adapted_state(BlockState state, LevelAccessor world, BlockPos pos)
   {
     BlockState below = world.getBlockState(pos.below());
-    if((below == null) || (state == null)) return state;
+    if (state.getValue(VARIANT) == 4) return state;
     if((below.getBlock() == ModContent.getBlock("thick_steel_pole")) || (below.getBlock() == ModContent.getBlock("thick_steel_pole_head"))) return state.setValue(VARIANT, 1);
     if((below.getBlock() == ModContent.getBlock("thin_steel_pole")) || (below.getBlock() == ModContent.getBlock("thin_steel_pole_head"))) return state.setValue(VARIANT, 2);
     return state;
+  }
+
+  @Override
+  public int getLightEmission(BlockState state, BlockGetter level, BlockPos pos) {
+    return state.getValue(VARIANT) == 4
+            ? inset_light_block.getLightEmission(inset_light_block.defaultBlockState().setValue(StandardBlocks.Directed.FACING, Direction.UP), level, pos)
+            : super.getLightEmission(state, level, pos);
+  }
+
+  @Override
+  public boolean hasDynamicDropList()
+  { return true; }
+
+  @Override
+  public List<ItemStack> dropList(BlockState state, Level world, @Nullable BlockEntity te, boolean explosion)
+  {
+    if(world.isClientSide()) return Collections.singletonList(ItemStack.EMPTY);
+    List<ItemStack> drops = new ArrayList<>();
+    drops.add(new ItemStack(state.getBlock().asItem()));
+    if (state.getValue(VARIANT) == 4) drops.add(new ItemStack(inset_light_block, 1));
+    return drops;
   }
 
 }

--- a/src/main/resources/assets/engineersdecor/blockstates/steel_catwalk_ta.json
+++ b/src/main/resources/assets/engineersdecor/blockstates/steel_catwalk_ta.json
@@ -3,6 +3,7 @@
     "variant=0": { "model": "engineersdecor:block/furniture/steel_catwalk_ta0_model" },
     "variant=1": { "model": "engineersdecor:block/furniture/steel_catwalk_ta1_model" },
     "variant=2": { "model": "engineersdecor:block/furniture/steel_catwalk_ta2_model" },
-    "variant=3": { "model": "engineersdecor:block/furniture/steel_catwalk_ta3_model" }
+    "variant=3": { "model": "engineersdecor:block/furniture/steel_catwalk_ta3_model" },
+    "variant=4": { "model": "engineersdecor:block/furniture/steel_catwalk_ta4_model" }
   }
 }

--- a/src/main/resources/assets/engineersdecor/models/block/furniture/steel_catwalk_ta4_model.json
+++ b/src/main/resources/assets/engineersdecor/models/block/furniture/steel_catwalk_ta4_model.json
@@ -1,0 +1,210 @@
+{
+	"parent": "block/block",
+	"ambientocclusion": false,
+	"textures": {
+		"particle": "engineersdecor:block/furniture/steel_catwalk_side",
+		"s": "engineersdecor:block/furniture/steel_catwalk_side",
+		"t": "engineersdecor:block/furniture/steel_catwalk_top",
+		"light": "engineersdecor:block/light/lamp_glass_warm_square_texture",
+		"side": "engineersdecor:block/material/steel_texture"
+	},
+	"elements": [
+
+		{
+			"from": [0, 14, 0],
+			"to": [16, 16, 1],
+			"rotation": {"angle": 0, "axis": "y", "origin": [8, 7.5, -0.25]},
+			"faces": {
+				"north": {"uv": [0, 14, 16, 16], "texture": "#s"},
+				"east": {"uv": [15, 14, 16, 16], "texture": "#s"},
+				"south": {"uv": [0, 14, 16, 16], "texture": "#s"},
+				"west": {"uv": [0, 14, 1, 16], "texture": "#s"},
+				"up": {"uv": [0, 0, 16, 1], "texture": "#s"},
+				"down": {"uv": [0, 15, 16, 16], "texture": "#s"}
+			}
+		},
+		{
+			"from": [15, 14, 1],
+			"to": [16, 16, 15],
+			"rotation": {"angle": 0, "axis": "y", "origin": [8, 7.5, 0.75]},
+			"faces": {
+				"east": {"uv": [1, 14, 15, 16], "texture": "#s"},
+				"west": {"uv": [1, 14, 15, 16], "texture": "#s"},
+				"up": {"uv": [15, 1, 16, 15], "texture": "#s"},
+				"down": {"uv": [15, 1, 16, 15], "texture": "#s"}
+			}
+		},
+		{
+			"from": [0, 14, 15],
+			"to": [16, 16, 16],
+			"rotation": {"angle": 0, "axis": "y", "origin": [8, 7.5, 14.75]},
+			"faces": {
+				"north": {"uv": [0, 14, 16, 16], "texture": "#s"},
+				"east": {"uv": [0, 14, 1, 16], "texture": "#s"},
+				"south": {"uv": [0, 14, 16, 16], "texture": "#s"},
+				"west": {"uv": [15, 14, 16, 16], "texture": "#s"},
+				"up": {"uv": [0, 15, 16, 16], "texture": "#s"},
+				"down": {"uv": [0, 0, 16, 1], "texture": "#s"}
+			}
+		},
+		{
+			"from": [0, 14, 1],
+			"to": [1, 16, 15],
+			"rotation": {"angle": 0, "axis": "y", "origin": [-7, 7.5, 0.75]},
+			"faces": {
+				"east": {"uv": [1, 14, 15, 16], "texture": "#s"},
+				"west": {"uv": [1, 14, 15, 16], "texture": "#s"},
+				"up": {"uv": [0, 1, 1, 15], "texture": "#s"},
+				"down": {"uv": [0, 1, 1, 15], "texture": "#s"}
+			}
+		},
+		{
+			"from": [1, 16, 1],
+			"to": [15, 16, 15],
+			"rotation": {"angle": 0, "axis": "y", "origin": [-6, 7.5, 0.75]},
+			"faces": {
+				"up": {"uv": [1, 1, 15, 15], "texture": "#t"},
+				"down": {"uv": [1, 1, 15, 15], "texture": "#t"}
+			}
+		},
+		{
+			"from": [1, 15, 1],
+			"to": [15, 15, 15],
+			"rotation": {"angle": 0, "axis": "y", "origin": [-6, 6.5, 0.75]},
+			"faces": {
+				"up": {"uv": [1, 1, 15, 15], "rotation": 90, "texture": "#t"},
+				"down": {"uv": [1, 1, 15, 15], "rotation": 90, "texture": "#t"}
+			}
+		},
+		{
+			"from": [6, 14.75, 6],
+			"to": [10, 14.875, 10],
+			"faces": {
+				"up": {"uv": [6, 6, 10, 10], "texture": "#light"},
+				"down": {"uv": [6, 6, 10, 10], "texture": "#light"}
+			}
+		},
+		{
+			"from": [10, 14.625, 7],
+			"to": [11, 15, 9],
+			"faces": {
+				"up": {"uv": [5, 7, 6, 9], "texture": "#side"},
+				"east": {"uv": [15.625, 7, 16, 9], "texture": "#side"},
+				"down": {"uv": [10, 7, 11, 9], "texture": "#side"},
+				"west": {"uv": [0, 7, 0.375, 9], "texture": "#side"},
+				"south": {"uv": [10, 0, 11, 0.375], "rotation": 180, "texture": "#side"},
+				"north": {"uv": [10, 15.625, 11, 16], "rotation": 180, "texture": "#side"}
+			}
+		},
+		{
+			"from": [5, 14.625, 7],
+			"to": [6, 15, 9],
+			"faces": {
+				"up": {"uv": [10, 7, 11, 9], "texture": "#side"},
+				"east": {"uv": [15.625, 7, 16, 9], "texture": "#side"},
+				"down": {"uv": [5, 7, 6, 9], "texture": "#side"},
+				"west": {"uv": [0, 7, 0.375, 9], "texture": "#side"},
+				"south": {"uv": [5, 0, 6, 0.375], "rotation": 180, "texture": "#side"},
+				"north": {"uv": [5, 15.625, 6, 16], "rotation": 180, "texture": "#side"}
+			}
+		},
+		{
+			"from": [7, 14.625, 10],
+			"to": [9, 15, 11],
+			"faces": {
+				"up": {"uv": [7, 5, 9, 6], "texture": "#side"},
+				"east": {"uv": [15.625, 5, 16, 6], "texture": "#side"},
+				"down": {"uv": [7, 5, 9, 6], "texture": "#side"},
+				"west": {"uv": [0, 5, 0.375, 6], "texture": "#side"},
+				"south": {"uv": [7, 0, 9, 0.375], "rotation": 180, "texture": "#side"},
+				"north": {"uv": [7, 15.625, 9, 16], "rotation": 180, "texture": "#side"}
+			}
+		},
+		{
+			"from": [7, 14.625, 5],
+			"to": [9, 15, 6],
+			"faces": {
+				"up": {"uv": [7, 10, 9, 11], "texture": "#side"},
+				"east": {"uv": [15.625, 10, 16, 11], "texture": "#side"},
+				"down": {"uv": [7, 10, 9, 11], "texture": "#side"},
+				"west": {"uv": [0, 10, 0.375, 11], "texture": "#side"},
+				"south": {"uv": [7, 0, 9, 0.375], "rotation": 180, "texture": "#side"},
+				"north": {"uv": [7, 15.625, 9, 16], "rotation": 180, "texture": "#side"}
+			}
+		},
+		{
+			"from": [6, 14.625, 9],
+			"to": [7, 15, 10],
+			"faces": {
+				"up": {"uv": [9, 6, 10, 7], "texture": "#side"},
+				"east": {"uv": [15.625, 6, 16, 7], "texture": "#side"},
+				"down": {"uv": [6, 6, 7, 7], "texture": "#side"},
+				"west": {"uv": [0, 6, 0.375, 7], "texture": "#side"},
+				"south": {"uv": [6, 0, 7, 0.375], "rotation": 180, "texture": "#side"},
+				"north": {"uv": [6, 15.625, 7, 16], "rotation": 180, "texture": "#side"}
+			}
+		},
+		{
+			"from": [6, 14.625, 6],
+			"to": [7, 15, 7],
+			"faces": {
+				"up": {"uv": [9, 9, 10, 10], "texture": "#side"},
+				"east": {"uv": [15.625, 9, 16, 10], "texture": "#side"},
+				"down": {"uv": [6, 9, 7, 10], "texture": "#side"},
+				"west": {"uv": [0, 9, 0.375, 10], "texture": "#side"},
+				"south": {"uv": [6, 0, 7, 0.375], "rotation": 180, "texture": "#side"},
+				"north": {"uv": [6, 15.625, 7, 16], "rotation": 180, "texture": "#side"}
+			}
+		},
+		{
+			"from": [9, 14.625, 6],
+			"to": [10, 15, 7],
+			"faces": {
+				"up": {"uv": [6, 9, 7, 10], "texture": "#side"},
+				"east": {"uv": [15.625, 9, 16, 10], "texture": "#side"},
+				"down": {"uv": [9, 9, 10, 10], "texture": "#side"},
+				"west": {"uv": [0, 9, 0.375, 10], "texture": "#side"},
+				"south": {"uv": [9, 0, 10, 0.375], "rotation": 180, "texture": "#side"},
+				"north": {"uv": [9, 15.625, 10, 16], "rotation": 180, "texture": "#side"}
+			}
+		},
+		{
+			"from": [9, 14.625, 9],
+			"to": [10, 15, 10],
+			"faces": {
+				"up": {"uv": [6, 6, 7, 7], "texture": "#side"},
+				"east": {"uv": [15.625, 6, 16, 7], "texture": "#side"},
+				"down": {"uv": [9, 6, 10, 7], "texture": "#side"},
+				"west": {"uv": [0, 6, 0.375, 7], "texture": "#side"},
+				"south": {"uv": [9, 0, 10, 0.375], "rotation": 180, "texture": "#side"},
+				"north": {"uv": [9, 15.625, 10, 16], "rotation": 180, "texture": "#side"}
+			}
+		}
+	],
+	"display": {
+		"thirdperson_righthand": {
+			"rotation": [70, -2, 3],
+			"translation": [0.25, 1, 1.75],
+			"scale": [0.3, 0.3, 0.3]
+		},
+		"firstperson_righthand": {
+			"rotation": [8, 0, 42],
+			"translation": [8.5, 0, -5.75],
+			"scale": [0.4, 0.4, 0.4]
+		},
+		"ground": {
+			"translation": [0, 1.75, 0],
+			"scale": [0.3, 0.3, 0.3]
+		},
+		"gui": {
+			"rotation": [30, 225, 0],
+			"translation": [0.25, 3, -3],
+			"scale": [0.6, 0.6, 0.6]
+		},
+		"fixed": {
+			"rotation": [-90, 0, 0],
+			"translation": [0, 0, -4],
+			"scale": [0.5, 0.5, 0.5]
+		}
+	}
+}


### PR DESCRIPTION
Inset lights are very cool and versatile, and pair well with catwalk blocks. Unfortunately, it's not possible to properly attach them to top-aligned catwalks, since you get almost an entire block of empty space between them. You have to use the framed variant, which takes up a lot of vertical space, or resort to bottom-aligned catwalks, which is not always convenient.

This PR adds functionality that is similar in design and implementation to interaction between bottom-aligned catwalks and railings. I tried to keep the original formatting style and cleaned up a few things.

![2022-05-22_19 51 42](https://user-images.githubusercontent.com/7419124/169707304-3ab055e7-60fd-42d4-95ca-babffa8bf0e1.png)

Additionally, I fixed VoxelShapes for inset and floor lights to make them match their actual shape.
