### PR TITLE
Various Iron hatch improvements

### DIFF
--- a/src/main/java/wile/engineersdecor/ModContent.java
+++ b/src/main/java/wile/engineersdecor/ModContent.java
@@ -298,9 +298,14 @@ public class ModContent
     ));
     Registries.addBlock("iron_hatch", ()->new EdHatchBlock(
       StandardBlocks.CFG_LOOK_PLACEMENT,
-      BlockBehaviour.Properties.of(Material.METAL, MaterialColor.METAL).strength(0.3f, 2000f).sound(SoundType.METAL).noOcclusion(),
-      Auxiliaries.getPixeledAABB(0.5,1,0, 15.5,3,14),
-      Auxiliaries.getPixeledAABB(0.5,1,0, 15.5,14.,2)
+      BlockBehaviour.Properties.of(Material.METAL, MaterialColor.METAL).strength(0.3f, 2000f).sound(SoundType.METAL),
+      new AABB[] { Auxiliaries.getPixeledAABB(0,0,0, 16,3,16) },
+      new AABB[] {
+        Auxiliaries.getPixeledAABB( 0,0, 0, 16,16, 3),
+        Auxiliaries.getPixeledAABB( 0,0, 3,  1, 1,16),
+        Auxiliaries.getPixeledAABB(15,0, 3, 16, 1,16),
+        Auxiliaries.getPixeledAABB( 1,0,14, 15, 1,16)
+      }
     ));
     Registries.addBlock("metal_sliding_door", ()->new StandardDoorBlock(
       StandardBlocks.CFG_TRANSLUCENT|StandardBlocks.CFG_HORIZIONTAL,

--- a/src/main/java/wile/engineersdecor/ModEngineersDecor.java
+++ b/src/main/java/wile/engineersdecor/ModEngineersDecor.java
@@ -110,7 +110,7 @@ public class ModEngineersDecor
   @SubscribeEvent
   public void onPlayerEvent(final LivingEvent.LivingUpdateEvent event)
   {
-    if((event.getEntity().level == null) || (!(event.getEntity() instanceof final Player player))) return;
+    if(!(event.getEntity() instanceof final Player player)) return;
     if(player.onClimbable()) EdLadderBlock.onPlayerUpdateEvent(player);
   }
 

--- a/src/main/java/wile/engineersdecor/blocks/EdHatchBlock.java
+++ b/src/main/java/wile/engineersdecor/blocks/EdHatchBlock.java
@@ -39,15 +39,14 @@ import wile.engineersdecor.libmc.blocks.StandardBlocks;
 import wile.engineersdecor.libmc.detail.Auxiliaries;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.List;
 
 
 public class EdHatchBlock extends StandardBlocks.HorizontalWaterLoggable
 {
   public static final BooleanProperty OPEN = BlockStateProperties.OPEN;
   public static final BooleanProperty POWERED = BlockStateProperties.POWERED;
-  protected final ArrayList<VoxelShape> vshapes_open;
+  protected final List<VoxelShape> vshapes_open;
 
   public EdHatchBlock(long config, BlockBehaviour.Properties builder, final AABB unrotatedAABBClosed, final AABB unrotatedAABBOpen)
   {
@@ -58,18 +57,16 @@ public class EdHatchBlock extends StandardBlocks.HorizontalWaterLoggable
   public EdHatchBlock(long config, BlockBehaviour.Properties builder, final AABB[] unrotatedAABBsClosed, final AABB[] unrotatedAABBsOpen)
   { super(config, builder, unrotatedAABBsClosed); vshapes_open = makeHorizontalShapeLookup(unrotatedAABBsOpen); }
 
-  protected static ArrayList<VoxelShape> makeHorizontalShapeLookup(final AABB[] unrotatedAABBs)
+  protected static List<VoxelShape> makeHorizontalShapeLookup(final AABB[] unrotatedAABBs)
   {
-    return new ArrayList<>(Arrays.asList(
+    return List.of(
       Shapes.block(),
       Shapes.block(),
       Auxiliaries.getUnionShape(Auxiliaries.getRotatedAABB(unrotatedAABBs, Direction.NORTH, true)),
       Auxiliaries.getUnionShape(Auxiliaries.getRotatedAABB(unrotatedAABBs, Direction.SOUTH, true)),
       Auxiliaries.getUnionShape(Auxiliaries.getRotatedAABB(unrotatedAABBs, Direction.WEST, true)),
-      Auxiliaries.getUnionShape(Auxiliaries.getRotatedAABB(unrotatedAABBs, Direction.EAST, true)),
-      Shapes.block(),
-      Shapes.block()
-    ));
+      Auxiliaries.getUnionShape(Auxiliaries.getRotatedAABB(unrotatedAABBs, Direction.EAST, true))
+    );
   }
 
   @Override
@@ -78,7 +75,7 @@ public class EdHatchBlock extends StandardBlocks.HorizontalWaterLoggable
 
   @Override
   public VoxelShape getShape(BlockState state, BlockGetter source, BlockPos pos, CollisionContext selectionContext)
-  { return state.getValue(OPEN) ? vshapes_open.get((state.getValue(HORIZONTAL_FACING)).get3DDataValue() & 0x7) : super.getShape(state, source, pos, selectionContext); }
+  { return state.getValue(OPEN) ? vshapes_open.get((state.getValue(HORIZONTAL_FACING)).get3DDataValue()) : super.getShape(state, source, pos, selectionContext); }
 
   @Override
   public VoxelShape getCollisionShape(BlockState state, BlockGetter source, BlockPos pos, CollisionContext selectionContext)
@@ -141,6 +138,18 @@ public class EdHatchBlock extends StandardBlocks.HorizontalWaterLoggable
   }
 
   @Override
+  @SuppressWarnings("deprecation")
+  public boolean useShapeForLightOcclusion(BlockState state) {
+    return !state.getValue(OPEN);
+  }
+
+  @Override
+  @SuppressWarnings("deprecation")
+  public VoxelShape getOcclusionShape(BlockState state, BlockGetter world, BlockPos pos) {
+    return state.getValue(OPEN) ? Shapes.empty() : super.getOcclusionShape(state, world, pos);
+  }
+
+  @Override
   public boolean shouldCheckWeakPower(BlockState state, LevelReader world, BlockPos pos, Direction side)
   { return false; }
 
@@ -149,13 +158,14 @@ public class EdHatchBlock extends StandardBlocks.HorizontalWaterLoggable
   public void entityInside(BlockState state, Level world, BlockPos pos, Entity entity)
   {
     if((!state.getValue(OPEN)) || (!(entity instanceof final Player player))) return;
+    if(player.isSteppingCarefully()) return;
     if(entity.getLookAngle().y() > -0.75) return;
     if(player.getDirection() != state.getValue(HORIZONTAL_FACING)) return;
     Vec3 ppos = player.position();
     Vec3 centre = Vec3.atBottomCenterOf(pos);
     Vec3 v = centre.subtract(ppos);
     if(ppos.y() < (centre.y()-0.1) || (v.lengthSqr() > 0.3)) return;
-    v = v.scale(0.3);
+    v = v.scale(0.2);
     player.push(v.x, -0.1, v.z);
   }
 }

--- a/src/main/java/wile/engineersdecor/blocks/EdLadderBlock.java
+++ b/src/main/java/wile/engineersdecor/blocks/EdLadderBlock.java
@@ -23,6 +23,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.LevelReader;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.LadderBlock;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
@@ -103,7 +104,8 @@ public class EdLadderBlock extends LadderBlock implements StandardBlocks.IStanda
     if(Math.abs(lvy) < 0.92) return;
     final BlockPos pos = player.blockPosition();
     final BlockState state = player.level.getBlockState(pos);
-    if(!(state.getBlock() instanceof EdLadderBlock)) return;
+    final Block block = state.getBlock();
+    if(!(block instanceof EdLadderBlock || block instanceof EdHatchBlock && state.getValue(EdHatchBlock.OPEN))) return;
     player.fallDistance = 0;
     if((player.getDeltaMovement().y() < 0) == (player.getLookAngle().y < 0)) {
       player.makeStuckInBlock(state, new Vec3(0.2, (lvy>0)?(3):(6), 0.2));

--- a/src/main/java/wile/engineersdecor/blocks/EdLadderBlock.java
+++ b/src/main/java/wile/engineersdecor/blocks/EdLadderBlock.java
@@ -103,10 +103,10 @@ public class EdLadderBlock extends LadderBlock implements StandardBlocks.IStanda
     double lvy = player.getLookAngle().y;
     if(Math.abs(lvy) < 0.92) return;
     final BlockPos pos = player.blockPosition();
-    final BlockState state = player.level.getBlockState(pos);
+    final BlockState state = player.getLevel().getBlockState(pos);
     final Block block = state.getBlock();
     if(!(block instanceof EdLadderBlock || block instanceof EdHatchBlock && state.getValue(EdHatchBlock.OPEN))) return;
-    player.fallDistance = 0;
+    player.resetFallDistance();
     if((player.getDeltaMovement().y() < 0) == (player.getLookAngle().y < 0)) {
       player.makeStuckInBlock(state, new Vec3(0.2, (lvy>0)?(3):(6), 0.2));
       if(Math.abs(player.getDeltaMovement().y()) > 0.1) {


### PR DESCRIPTION
This PR contains a few improvements to the iron hatch. The initial idea was to add the same speed-up mechanic which is present on metal rung ladders, but I took opportunity to add a few extra things. The complete changelist is as follows:

- Open iron hatches now provide the same speed boost as ladders
- Hatch shape was modified in both states:
    - Open hatch is now 3 pixels thick, which matches both your and vanilla ladders, reducing the risk of being stuck on an invisible edge; the horizontal rim is now also part of the shape
    - Closed hatch now covers the entire block, which allowed to implement sunlight blocking
- The suction mechanic of the hatch was weakened a bit (from 0.3 to 0.2), as it tended to overshoot and made you bump upwards, as if you're about to climb the opposite side of the block, which was a bit annoying
- Suction is disabled when crouching
- A bit of refactoring